### PR TITLE
[Bromite Builder] [Prepare] Use ungoogled-chromium for domain substitutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bromite Builder
 
-Utility script for building [Bromite]( https://github.com/bromite/bromite) releases
+Utility script for building [Bromite](https://github.com/bromite/bromite) releases
 
 - [Requirements](#requirements)
 - [Setup](#setup)
@@ -13,7 +13,8 @@ Utility script for building [Bromite]( https://github.com/bromite/bromite) relea
 - A 64-bit Intel machine running Linux with at least 8GB of RAM.
 More than 16GB is highly recommended.
 - At least 100GB of free disk space.
-- You must have Git and Python 2 installed already.
+- Git and Python 2 for checking out and building Chromium
+- Python 3 for [Ungoogled Chromium's](https://github.com/Eloston/ungoogled-chromium) domain substitution utility
 
 ## <a name="setup"></a>Setup
 

--- a/bromite-builder
+++ b/bromite-builder
@@ -153,6 +153,7 @@ prepare () {
     local bromite_src
     local patchlist_path
     local patchlist
+    local ungoogled_dir
 
     [[ ! -d $BUILD_DIR/chromium/src ]] \
         && fetch-sync
@@ -211,14 +212,29 @@ prepare () {
 
     # Apply Patches
     for patchfile in "${patchlist[@]}"; do
+        [[ "$patchfile" =~ domain-substitution.patch ]] \
+            && continue
+
         [[ "$(git apply --whitespace=nowarn --check "$patchfile" &>/dev/null; \
                 echo $?)" -gt 0 ]] \
             && [[ ! $NO_SKIP_PATCHES ]] \
             && echo "Skipping, doesn't apply: $(basename "$patchfile")" \
             && continue
+
         echo "Applying patch: $(basename "$patchfile")"
         git apply --whitespace=nowarn "$patchfile"
     done
+
+    # Domain Substitution
+    echo "Applying Ungoogled Chromium's domain substitutions"
+    ungoogled_dir="$CWD/.bin/ungoogled-chromium"
+    rm -f "$ungoogled_dir/build/domainsubcache.tar.gz"
+
+    domain_substitution --quiet apply \
+        -r "$ungoogled_dir/domain_regex.list" \
+        -f "$ungoogled_dir/domain_substitution.list" \
+        -c "$ungoogled_dir/build/domainsubcache.tar.gz" \
+        ./
 }
 
 build () {
@@ -458,6 +474,21 @@ _localbin () {
         && curl -s "$protobuf_repo/protoc-gen-javalite/3.0.0/$protoc_javalite_bin" \
             -o "$CWD/.bin/protoc-gen-javalite" \
         && chmod 755 "$CWD/.bin/protoc-gen-javalite"
+
+    # Ungoogled Chromium
+    [[ ! -d $CWD/.bin/ungoogled-chromium ]] \
+        && cd "$CWD/.bin" \
+        && echo "Fetching Ungoogled Chromium" \
+        && git clone -q https://github.com/Eloston/ungoogled-chromium.git
+
+    cd "$CWD/.bin/ungoogled-chromium"
+    git checkout master -q
+    git pull -q
+
+    mkdir -p "$CWD/.bin/ungoogled-chromium/build"
+
+    ln -sf "$CWD/.bin/ungoogled-chromium/utils/domain_substitution.py" \
+        "$CWD/.bin/domain_substitution"
 }
 
 _getcmds () {

--- a/bromite-builder
+++ b/bromite-builder
@@ -151,9 +151,13 @@ fetch-sync () {
 prepare () {
     local bromite_dir
     local bromite_src
+
     local patchlist_path
     local patchlist
+    local patch_status
+
     local ungoogled_dir
+    local ungoogled_domains_fallback=
 
     [[ ! -d $BUILD_DIR/chromium/src ]] \
         && fetch-sync
@@ -212,11 +216,16 @@ prepare () {
 
     # Apply Patches
     for patchfile in "${patchlist[@]}"; do
-        [[ "$patchfile" =~ domain-substitution.patch ]] \
+        patch_status=$(git apply --whitespace=nowarn --check "$patchfile" \
+            &>/dev/null; \
+            echo $?)
+
+        [[ $patch_status -gt 0 ]] \
+            && [[ "$patchfile" =~ domain-substitution.patch ]] \
+            && ungoogled_domains_fallback=$patch_status \
             && continue
 
-        [[ "$(git apply --whitespace=nowarn --check "$patchfile" &>/dev/null; \
-                echo $?)" -gt 0 ]] \
+        [[ $patch_status -gt 0 ]] \
             && [[ ! $NO_SKIP_PATCHES ]] \
             && echo "Skipping, doesn't apply: $(basename "$patchfile")" \
             && continue
@@ -225,16 +234,16 @@ prepare () {
         git apply --whitespace=nowarn "$patchfile"
     done
 
-    # Domain Substitution
-    echo "Applying Ungoogled Chromium's domain substitutions"
-    ungoogled_dir="$CWD/.bin/ungoogled-chromium"
-    rm -f "$ungoogled_dir/build/domainsubcache.tar.gz"
-
-    domain_substitution --quiet apply \
-        -r "$ungoogled_dir/domain_regex.list" \
-        -f "$ungoogled_dir/domain_substitution.list" \
-        -c "$ungoogled_dir/build/domainsubcache.tar.gz" \
-        ./
+    # Domain Substitution Fallback via Ungoogled
+    [[ $ungoogled_domains_fallback ]] \
+        && echo "Applying Ungoogled Chromium's domain substitutions" \
+        && ungoogled_dir="$CWD/.bin/ungoogled-chromium" \
+        && rm -f "$ungoogled_dir/build/domainsubcache.tar.gz" \
+        && domain_substitution --quiet apply \
+            -r "$ungoogled_dir/domain_regex.list" \
+            -f "$ungoogled_dir/domain_substitution.list" \
+            -c "$ungoogled_dir/build/domainsubcache.tar.gz" \
+            ./
 }
 
 build () {


### PR DESCRIPTION
@csagan5 the `Automated-domain-substitutions.patch` patch file has the potential of being a source of constant failures -- it's a lot to manage, especially when just one hunk of its 4mb contents could cause rejections.

So this branch was created to explore using ungoogled-chromium's `domain_substitution.py` to dynamically apply the substitutions before builds.

Do you use a custom `domain_regex.list` or `domain_substitution.list`? If you do, is there anyway you'd be able to start checking those in?

I might revert this feature (or turn this into a user option), if the next few releases the patch applies cleanly. 

If you don't feel like maintaining such a patch file, there's always other routes you could take in the Bromite repo:

1. Add a note to the `README` explaining how to use ungoogled-chromium's` domain-substitution.py` when building locally
2. Add ungoogled-chromium as a sparse and shallow submodule and only add `utils/domain-substitution.py`, `domain_regex.list` and `domain_substitution.list`

Thanks in advance for any insights!